### PR TITLE
Fix lineterminator settings

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -84,9 +84,8 @@ var CSV = {};
   // http://www.uselesscode.org/javascript/csv/
   my.parse= function(s, dialect) {
     // Get rid of any trailing \n
-    s = chomp(s);
-
     var options = my.normalizeDialectOptions(dialect);
+    s = chomp(s, options.lineterminator);
 
     var cur = '', // The character we are currently processing.
       inQuote = false,
@@ -121,12 +120,12 @@ var CSV = {};
       cur = s.charAt(i);
 
       // If we are at a EOF or EOR
-      if (inQuote === false && (cur === options.delimiter || cur === "\n")) {
+      if (inQuote === false && (cur === options.delimiter || cur === options.lineterminator)) {
         field = processField(field);
         // Add the current field to the current row
         row.push(field);
         // If this is EOR append row to output and flush row
-        if (cur === "\n") {
+        if (cur === options.lineterminator) {
           out.push(row);
           row = [];
         }
@@ -235,7 +234,7 @@ var CSV = {};
         // If this is EOR append row to output and flush row
         if (j === (cur.length - 1)) {
           row += field;
-          out += row + "\n";
+          out += row + options.lineterminator;
           row = '';
         } else {
           // Add the current field to the current row
@@ -268,13 +267,13 @@ var CSV = {};
       }
     }());
 
-  function chomp(s) {
-    if (s.charAt(s.length - 1) !== "\n") {
+  function chomp(s, lineterminator) {
+    if (s.charAt(s.length - lineterminator.length) !== lineterminator) {
       // Does not end with \n, just return string
       return s;
     } else {
       // Remove the \n
-      return s.substring(0, s.length - 1);
+      return s.substring(0, s.length - lineterminator.length);
     }
   }
 }(CSV));

--- a/test/tests.js
+++ b/test/tests.js
@@ -140,6 +140,26 @@ asyncTest("request fail", function(){
   });
 });
 
+test("parse custom lineterminator", function(){
+  var csv = '"Jones, Jay",10\r' +
+  '"Xyz ""ABC"" O\'Brien",11:35\r' +
+  '"Other, AN",12:35\r';
+
+  var exp = [
+    ['Jones, Jay', 10],
+    ['Xyz "ABC" O\'Brien', '11:35' ],
+    ['Other, AN', '12:35' ]
+  ];
+
+  var settings = {
+    delimiter: ',',
+    lineterminator: '\r',
+  };
+
+  var array = CSV.parse(csv, settings);
+  deepEqual(array, exp);
+});
+
 test('normalizeDialectOptions', function() {
   var indata = {
   };


### PR DESCRIPTION
It replaces all the ```\n``` occurrences with the dialect.lineterminator value. 

Acceptance test
----------------------
- [ ] Parse a file with ```\r``` as line ending

I've also created a test in the test.js file. 

Ref: okfn/csv.js#11
