### PR TITLE
Add line terminator heuristic

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -83,6 +83,13 @@ var CSV = {};
   // Heavily based on uselesscode's JS CSV parser (MIT Licensed):
   // http://www.uselesscode.org/javascript/csv/
   my.parse= function(s, dialect) {
+
+    // When line terminator is not provided then we try to guess it
+    // and normalize it across the file.
+    if(!dialect || (dialect && !dialect.lineterminator)) {
+      s = my.normalizeLineTerminator(s, dialect);
+    }
+
     // Get rid of any trailing \n
     s = chomp(s);
 
@@ -166,6 +173,22 @@ var CSV = {};
     if (options.skipinitialrows) out = out.slice(options.skipinitialrows);
 
     return out;
+  };
+
+  my.normalizeLineTerminator = function(csv_string, dialect){
+    var lineTerminators = ['\n\r', '\r', '\n'];
+    var chunk = csv_string.substring(0, 4096);
+    var ocurrences = 0;
+    var lineterminator, parts;
+
+    for(var i = 0; i < lineTerminators.length; i++) {
+      if(chunk.search(lineTerminators[i]) > ocurrences) {
+        lineterminator = lineTerminators[i];
+      }
+    }
+    console.log(lineterminator.codePointAt(0));
+    parts = csv_string.split(lineterminator);
+    return parts.join((dialect && dialect.lineterminator) ? dialect.lineterminator : '\n');
   };
 
   my.objectToArray = function(dataToSerialize) {

--- a/csv.js
+++ b/csv.js
@@ -185,7 +185,6 @@ var CSV = {};
         lineterminator = lineTerminators[i];
       }
     }
-    console.log(lineterminator.codePointAt(0));
     parts = csv_string.split(lineterminator);
     return parts.join((dialect && dialect.lineterminator) ? dialect.lineterminator : '\n');
   };

--- a/test/tests.js
+++ b/test/tests.js
@@ -219,6 +219,17 @@ test('normalizeLineTerminator', function() {
   array = CSV.parse(csv);
   deepEqual(exp, array);
 
+  // Override line terminator
+  var settings = {
+    delimiter: ',',
+    lineterminator: '\r',
+  };
+  csv = '"Jones, Jay",10\r' +
+  '"Xyz ""ABC"" O\'Brien",11:35\r' +
+  '"Other, AN",12:35\r';
+  array = CSV.parse(csv, settings);
+  deepEqual(exp, array);
+
 });
 
 })(this.jQuery);

--- a/test/tests.js
+++ b/test/tests.js
@@ -170,4 +170,35 @@ test('normalizeDialectOptions', function() {
   deepEqual(out, exp);
 });
 
+test('normalizeLineTerminator', function() {
+  var exp = [
+    ['Jones, Jay', 10],
+    ['Xyz "ABC" O\'Brien', '11:35' ],
+    ['Other, AN', '12:35' ]
+  ];
+  var csv, array;
+
+  // Multics, Unix and Unix-like systems (Linux, OS X, FreeBSD, AIX, Xenix, etc.), BeOS, Amiga, RISC OS, and other
+  csv = '"Jones, Jay",10\n' +
+  '"Xyz ""ABC"" O\'Brien",11:35\n' +
+  '"Other, AN",12:35\n';
+  array = CSV.parse(csv);
+  deepEqual(exp, array);
+
+  // Commodore 8-bit machines, Acorn BBC, ZX Spectrum, TRS-80, Apple II family, Oberon, Mac OS up to version 9, and OS-9
+  csv = '"Jones, Jay",10\r' +
+  '"Xyz ""ABC"" O\'Brien",11:35\r' +
+  '"Other, AN",12:35\r';
+  array = CSV.parse(csv);
+  deepEqual(exp, array);
+
+  // Microsoft Windows, DOS (MS-DOS, PC DOS, etc.),
+  csv = '"Jones, Jay",10\r\n' +
+  '"Xyz ""ABC"" O\'Brien",11:35\r\n' +
+  '"Other, AN",12:35\r\n';
+  array = CSV.parse(csv);
+  deepEqual(exp, array);
+
+});
+
 })(this.jQuery);


### PR DESCRIPTION
Most of time people expect to parse a CSV regardless line terminator. This PR adds a method to guess the line terminator of the stream if no line terminator is provided. However if a line terminator is provided by configuration it will use it. 

Before parsing the file it unify all the line endings to `\n`. To be performant it only reads the first 4096 characters of the stream.