### PR TITLE
Consider nested and mixed line terminators during parsing

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -174,19 +174,15 @@ var CSV = {};
     return out;
   };
 
-  my.normalizeLineTerminator = function(csv_string, dialect){
-    var lineTerminators = ['\n\r', '\r', '\n'];
-    var chunk = csv_string.substring(0, 4096);
-    var ocurrences = 0;
-    var lineterminator, parts;
+  my.normalizeLineTerminator = function(csvString, dialect){
+    dialect = dialect || {};
 
-    for(var i = 0; i < lineTerminators.length; i++) {
-      if(chunk.search(lineTerminators[i]) > ocurrences) {
-        lineterminator = lineTerminators[i];
-      }
+    // Try to guess line terminator if it's not provided.
+    if (!dialect.lineterminator) {
+      return csvString.replace(/(\r\n|\n|\r)/gm, '\n');
     }
-    parts = csv_string.split(lineterminator);
-    return parts.join((dialect && dialect.lineterminator) ? dialect.lineterminator : '\n');
+    // if not return the string untouched.
+    return csvString;
   };
 
   my.objectToArray = function(dataToSerialize) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -230,6 +230,18 @@ test('normalizeLineTerminator', function() {
   array = CSV.parse(csv, settings);
   deepEqual(exp, array);
 
+  // Nested mixed terminators
+  var exp = [
+    ['Jones,\n Jay', 10],
+    ['Xyz "ABC" O\'Brien', '11:35' ],
+    ['Other, AN', '12:35' ]
+  ];
+  csv = '"Jones,\n Jay",10\r' +
+  '"Xyz ""ABC"" O\'Brien",11:35\r' +
+  '"Other, AN",12:35\r';
+  array = CSV.parse(csv, settings);
+  deepEqual(exp, array);
+
 });
 
 })(this.jQuery);


### PR DESCRIPTION
Previous algorithm didn't consider nested and mixed line terminators. It was only searching for the first occurrence of a line terminator and setting that as the valid one. However this is not always true. 

This new algorithm handle those edge cases. There are some comments in the code as well. And yes there is no problem with the MIT license.